### PR TITLE
Fix panic when abbreviating empty strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,8 @@ fn get_first_letter(word: &str) -> String {
 }
 
 fn get_last_letter(word: &str) -> String {
-    return get_nth_letter(word, (word.chars().count() - 1) as u16);
+    let index = word.chars().count().saturating_sub(1);
+    return get_nth_letter(word, index as u16);
 }
 
 #[cfg(test)]
@@ -41,10 +42,7 @@ mod tests {
         assert_eq!(get_last_letter("hello"), "o");
         assert_eq!(get_last_letter("HELLO"), "O");
         assert_eq!(get_last_letter("a"), "a");
-        // Todo:
-        // Even though this function will never be called with an empty string
-        // I have to fix this issue some time.
-        // assert_eq!(get_last_letter(""), "");
+        assert_eq!(get_last_letter(""), "");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,10 @@ pub fn abbreviate(word: &str) -> String {
 }
 
 fn get_nth_letter(word: &str, index: u16) -> String {
+    if word.is_empty() {
+        return word.to_string();
+    }
+
     return word.chars().nth(index as usize).unwrap().to_string();
 }
 
@@ -29,10 +33,7 @@ mod tests {
         assert_eq!(get_first_letter("hello"), "h");
         assert_eq!(get_first_letter("HELLO"), "H");
         assert_eq!(get_first_letter("a"), "a");
-        // Todo:
-        // Even though this function will never be called with an empty string
-        // I have to fix this issue some time.
-        // assert_eq!(get_first_letter(""), "");
+        assert_eq!(get_first_letter(""), "");
     }
 
     #[test]


### PR DESCRIPTION
Hello!

The reason you got those panics is because [unsigned numbers](https://en.wikipedia.org/w/index.php?title=Unsigned_integers) (`u16`, `usize`, etc) cannot hold negative values _at all_. In most over languages (and in Rust's release mode) we'd get [a very large number](https://en.wikipedia.org/wiki/Integer_overflow) when subtracting `1` from `0`. Issues like these can cause quite a few [nasty bugs](https://www.pcgamer.com/old-school-runescape-pulled-offline-as-billions-of-gold-appear-out-of-nowhere/), so the long term goal of Rust is to prevent this from happening. However, for performance reasons it only does so in debug mode at the moment.

I've used [saturating subtraction](https://doc.rust-lang.org/std/primitive.usize.html#method.saturating_sub) to make sure the number doesn't overflow when subtracting `1` from `0`. I think this makes the code a little bit cleaner compared to adding another if-statement.

Perhaps you know this already, but I hope it was useful either way!

Thanks for all the videos!