### PR TITLE
Handle grapheme clusters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,3 +5,12 @@ version = 3
 [[package]]
 name = "abbreviator"
 version = "0.1.6"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,3 +7,6 @@ description = "A library for abbreviating long words."
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Vagelis-Prokopiou/abbreviator"
 readme = "README.md"
+
+[dependencies]
+unicode-segmentation = "1.10.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,8 +61,7 @@ mod tests {
     }
 
     #[test]
-    fn test_abbreviate() {
-        // English
+    fn test_abbreviate_english() {
         assert_eq!(abbreviate(""), "");
         assert_eq!(abbreviate("a"), "a");
         assert_eq!(abbreviate("ab"), "ab");
@@ -71,15 +70,19 @@ mod tests {
         assert_eq!(abbreviate("localization"), "l10n");
         assert_eq!(abbreviate("internationalization"), "i18n");
         assert_eq!(abbreviate("pneumonoultramicroscopicsilicovolcanoconiosis"), "p43s");
+    }
 
-        // Greek
+    #[test]
+    fn test_abbreviate_greek() {
         assert_eq!(abbreviate("τι κάνεις"), "τ7ς");
         assert_eq!(abbreviate("Καλημέρα αρχηγέ"), "Κ13έ");
         assert_eq!(abbreviate("Άντε και στα δικά σου!"), "Ά20!");
         assert_eq!(abbreviate("σκουλικομερμυγκότρυπα"), "σ19α");
         assert_eq!(abbreviate("Άσπρη πέτρα ξέξασπρη κι απ' τον ήλιο ξεξασπρώτερη"), "Ά47η");
+    }
 
-        // Misc
+    #[test]
+    fn test_abbreviate_grapheme_clusters() {
         // https://doc.rust-lang.org/book/ch08-02-strings.html#creating-a-new-string
         // https://unicode-rs.github.io/unicode-segmentation/unicode_segmentation/trait.UnicodeSegmentation.html#tymethod.grapheme_indices
         assert_eq!(abbreviate("عليكم"), "ع3م");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,15 @@
+use unicode_segmentation::{Graphemes, UnicodeSegmentation};
+
 pub fn abbreviate(word: &str) -> String {
-    let word_length = word.chars().count();
+    let word_length = graphemes_count(word);
     if word_length < 3 {
         return word.to_string();
     }
     /*
-        At this point of the code the following unwraps should always  
+        At this point of the code the following unwraps should always
         succeed because they can only return None if the word is empty.
 
-        If they fail they return the default value for char, which is '\x00':
-        https://doc.rust-lang.org/std/primitive.char.html#impl-Default-for-char
+        If they fail they return the default empty string "".
     */
     format!(
         "{}{}{}",
@@ -18,17 +19,25 @@ pub fn abbreviate(word: &str) -> String {
     )
 }
 
-fn get_nth_letter(word: &str, index: usize) -> Option<char> {
-    word.chars().nth(index)
+fn get_nth_letter(word: &str, index: usize) -> Option<&str> {
+    word_graphemes(word).nth(index)
 }
 
-fn get_first_letter(word: &str) -> Option<char> {
+fn get_first_letter(word: &str) -> Option<&str> {
     get_nth_letter(word, 0)
 }
 
-fn get_last_letter(word: &str) -> Option<char> {
-    let index = word.chars().count().saturating_sub(1);
+fn get_last_letter(word: &str) -> Option<&str> {
+    let index = graphemes_count(word).saturating_sub(1);
     get_nth_letter(word, index)
+}
+
+fn word_graphemes(word: &str) -> Graphemes {
+    word.graphemes(true)
+}
+
+fn graphemes_count(word: &str) -> usize {
+    word_graphemes(word).count()
 }
 
 #[cfg(test)]
@@ -37,17 +46,17 @@ mod tests {
 
     #[test]
     fn test_get_first_letter() {
-        assert_eq!(get_first_letter("hello"), Some('h'));
-        assert_eq!(get_first_letter("HELLO"), Some('H'));
-        assert_eq!(get_first_letter("a"), Some('a'));
+        assert_eq!(get_first_letter("hello"), Some("h"));
+        assert_eq!(get_first_letter("HELLO"), Some("H"));
+        assert_eq!(get_first_letter("a"), Some("a"));
         assert_eq!(get_first_letter(""), None);
     }
 
     #[test]
     fn test_get_last_letter() {
-        assert_eq!(get_last_letter("hello"), Some('o'));
-        assert_eq!(get_last_letter("HELLO"), Some('O'));
-        assert_eq!(get_last_letter("a"), Some('a'));
+        assert_eq!(get_last_letter("hello"), Some("o"));
+        assert_eq!(get_last_letter("HELLO"), Some("O"));
+        assert_eq!(get_last_letter("a"), Some("a"));
         assert_eq!(get_last_letter(""), None);
     }
 
@@ -69,5 +78,21 @@ mod tests {
         assert_eq!(abbreviate("Άντε και στα δικά σου!"), "Ά20!");
         assert_eq!(abbreviate("σκουλικομερμυγκότρυπα"), "σ19α");
         assert_eq!(abbreviate("Άσπρη πέτρα ξέξασπρη κι απ' τον ήλιο ξεξασπρώτερη"), "Ά47η");
+
+        // Misc
+        // https://doc.rust-lang.org/book/ch08-02-strings.html#creating-a-new-string
+        // https://unicode-rs.github.io/unicode-segmentation/unicode_segmentation/trait.UnicodeSegmentation.html#tymethod.grapheme_indices
+        assert_eq!(abbreviate("عليكم"), "ع3م");
+        assert_eq!(abbreviate("السلام"), "ا4م");
+        assert_eq!(abbreviate("Dobrý"), "D3ý");
+        assert_eq!(abbreviate("שָׁלוֹם"), "שָׁ2ם");
+        assert_eq!(abbreviate("नमस्ते"), "न2ते");
+        assert_eq!(abbreviate("こんにちは"), "こ3は");
+        assert_eq!(abbreviate("안녕하세요"), "안3요");
+        assert_eq!(abbreviate("你好"), "你好");
+        assert_eq!(abbreviate("Olá"), "O1á");
+        assert_eq!(abbreviate("Здравствуйте"), "З10е");
+        assert_eq!(abbreviate("Hola"), "H2a");
+        assert_eq!(abbreviate("a̐éö̲"), "a̐1ö̲");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,27 +3,30 @@ pub fn abbreviate(word: &str) -> String {
     if word_length < 3 {
         return word.to_string();
     }
+    /*
+        At this point of the code the following unwraps should always  
+        succeed because they can only return None if the word is empty.
+
+        If they fail they return the default value for char, which is '\x00':
+        https://doc.rust-lang.org/std/primitive.char.html#impl-Default-for-char
+    */
     format!(
         "{}{}{}",
-        get_first_letter(word),
+        get_first_letter(word).unwrap_or_default(),
         word_length - 2,
-        get_last_letter(word)
+        get_last_letter(word).unwrap_or_default()
     )
 }
 
-fn get_nth_letter(word: &str, index: usize) -> String {
-    if word.is_empty() {
-        return word.to_string();
-    }
-
-    return word.chars().nth(index).unwrap().to_string();
+fn get_nth_letter(word: &str, index: usize) -> Option<char> {
+    word.chars().nth(index)
 }
 
-fn get_first_letter(word: &str) -> String {
+fn get_first_letter(word: &str) -> Option<char> {
     get_nth_letter(word, 0)
 }
 
-fn get_last_letter(word: &str) -> String {
+fn get_last_letter(word: &str) -> Option<char> {
     let index = word.chars().count().saturating_sub(1);
     get_nth_letter(word, index)
 }
@@ -34,18 +37,18 @@ mod tests {
 
     #[test]
     fn test_get_first_letter() {
-        assert_eq!(get_first_letter("hello"), "h");
-        assert_eq!(get_first_letter("HELLO"), "H");
-        assert_eq!(get_first_letter("a"), "a");
-        assert_eq!(get_first_letter(""), "");
+        assert_eq!(get_first_letter("hello"), Some('h'));
+        assert_eq!(get_first_letter("HELLO"), Some('H'));
+        assert_eq!(get_first_letter("a"), Some('a'));
+        assert_eq!(get_first_letter(""), None);
     }
 
     #[test]
     fn test_get_last_letter() {
-        assert_eq!(get_last_letter("hello"), "o");
-        assert_eq!(get_last_letter("HELLO"), "O");
-        assert_eq!(get_last_letter("a"), "a");
-        assert_eq!(get_last_letter(""), "");
+        assert_eq!(get_last_letter("hello"), Some('o'));
+        assert_eq!(get_last_letter("HELLO"), Some('O'));
+        assert_eq!(get_last_letter("a"), Some('a'));
+        assert_eq!(get_last_letter(""), None);
     }
 
     #[test]


### PR DESCRIPTION
Given that your library deals primarily with strings that are words from possibly different languages, I thought it would only be natural to add support for complex grapheme clusters. This way you can abbreviate words from virtually any language supported by UTF-8 and the library can be used by anyone in the world.

The idea came to me after seeing that you used to count the chars by calling `.chars().count()`, which certainly works for strings written in plain Latin alphabet like what I'm using right now. However, when you try it on certain foreign languages it produces unexpected results and it doesn't work as you might have intended, as explained [here](https://doc.rust-lang.org/book/ch08-02-strings.html#indexing-into-strings). Make sure to check out the [library](https://docs.rs/unicode-segmentation/latest/unicode_segmentation/) I've used, which is opt-in instead of being part of the language itself.